### PR TITLE
multiple fixes for backend

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4860,9 +4860,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,15 +21,15 @@ services:
       client:
         condition: service_completed_successfully
     volumes:
-      - client_build:/app/static:ro
+      - client_build:/static:ro
     expose:
       - "4000"
     environment:
       - GO_ENV=production
       - PORT=4000
-      - STATIC_DIR=./static
+      - STATIC_DIR=/static
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:4000/healthz || exit 1"]
+      test: ["CMD", "/healthcheck"]
       interval: 10s
       timeout: 3s
       retries: 5

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.25
+# ── Build stage ────────────────────────────────────────────────
+FROM golang:1.26 AS builder
 
 WORKDIR /app
 
@@ -6,9 +7,19 @@ WORKDIR /app
 COPY go.mod ./
 RUN go mod download
 
-# Copy server source
+# Copy server source and compile static binaries
 COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /server ./cmd/api
+RUN CGO_ENABLED=0 GOOS=linux go build -o /healthcheck ./cmd/healthcheck
+
+# ── Runtime stage ──────────────────────────────────────────────
+# Distroless contains no shell, no package manager, no libc —
+# only the binaries and TLS root certificates.
+FROM gcr.io/distroless/static-debian12
+
+COPY --from=builder /server /server
+COPY --from=builder /healthcheck /healthcheck
 
 EXPOSE 4000
 
-CMD ["go", "run", "./cmd/api"]
+CMD ["/server"]

--- a/server/cmd/api/main.go
+++ b/server/cmd/api/main.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"context"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"BrandonDHaskell-React-Site/server/internal/config"
 	"BrandonDHaskell-React-Site/server/internal/handlers"
+	"BrandonDHaskell-React-Site/server/internal/middleware"
 )
 
 func main() {
@@ -23,16 +28,42 @@ func main() {
 	// Serve React static build with SPA fallback
 	mux.Handle("/", handlers.SPAHandler(cfg.StaticDir))
 
+	// Apply CORS middleware to all routes
+	handler := middleware.CORS(cfg.CORSOrigins)(mux)
+
 	srv := &http.Server{
 		Addr:         ":" + cfg.Port,
-		Handler:      mux,
+		Handler:      handler,
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
 		IdleTimeout:  60 * time.Second,
 	}
 
-	log.Printf("env=%s | listening on :%s | static=%s", cfg.Env, cfg.Port, cfg.StaticDir)
-	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		log.Fatalf("server error: %v", err)
+	// Listen for SIGINT (Ctrl+C) and SIGTERM (systemctl stop/restart).
+	// When received, the context cancels and we begin graceful shutdown.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// Start the server in a goroutine so the main goroutine can wait for signals
+	go func() {
+		log.Printf("env=%s | listening on :%s | static=%s", cfg.Env, cfg.Port, cfg.StaticDir)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("server error: %v", err)
+		}
+	}()
+
+	// Block until a shutdown signal is received
+	<-ctx.Done()
+	log.Println("shutdown signal received, draining connections...")
+
+	// Give in-flight requests a deadline to complete before forcing a stop.
+	// This should be shorter than the systemd stop_grace_period (20s in docker-compose).
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Fatalf("forced shutdown: %v", err)
 	}
+
+	log.Println("server stopped gracefully")
 }

--- a/server/cmd/healthcheck/main.go
+++ b/server/cmd/healthcheck/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"time"
+)
+
+// healthcheck is a minimal binary used by Docker's HEALTHCHECK directive.
+// Distroless images have no shell, curl, or wget, so this replaces
+// the typical "CMD-SHELL curl -f ..." approach.
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "4000"
+	}
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get("http://localhost:" + port + "/healthz")
+	if err != nil || resp.StatusCode != http.StatusOK {
+		os.Exit(1)
+	}
+}

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,3 +1,3 @@
 module BrandonDHaskell-React-Site/server
 
-go 1.25.3
+go 1.26

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type Config struct {
@@ -11,10 +12,13 @@ type Config struct {
 	Env       string
 	StaticDir string
 
+	// Comma-separated list of allowed CORS origins.
+	// Defaults to the production domain; set CORS_ORIGINS="*" only for local dev.
+	CORSOrigins []string
+
 	// Future use — leave empty until features require them
 	DatabaseURL   string
 	SessionSecret string
-	CORSOrigins   string
 }
 
 func Load() Config {
@@ -22,9 +26,9 @@ func Load() Config {
 		Port:          envOrDefault("PORT", "4000"),
 		Env:           envOrDefault("GO_ENV", "development"),
 		StaticDir:     envOrDefault("STATIC_DIR", "./static"),
+		CORSOrigins:   parseOrigins(envOrDefault("CORS_ORIGINS", "https://brandondhaskell.com,https://www.brandondhaskell.com")),
 		DatabaseURL:   os.Getenv("DATABASE_URL"),
 		SessionSecret: os.Getenv("SESSION_SECRET"),
-		CORSOrigins:   envOrDefault("CORS_ORIGINS", "*"),
 	}
 
 	// Resolve static dir to absolute path and validate
@@ -49,4 +53,17 @@ func envOrDefault(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// parseOrigins splits a comma-separated origin string into a trimmed slice.
+// Example: "https://example.com, https://www.example.com" → ["https://example.com", "https://www.example.com"]
+func parseOrigins(raw string) []string {
+	parts := strings.Split(raw, ",")
+	origins := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			origins = append(origins, trimmed)
+		}
+	}
+	return origins
 }

--- a/server/internal/handlers/handlers.go
+++ b/server/internal/handlers/handlers.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func HealthHandler(w http.ResponseWriter, r *http.Request) {
@@ -28,15 +29,29 @@ func HelloHandler(w http.ResponseWriter, r *http.Request) {
 // SPAHandler serves static files from the given directory. If the requested
 // file does not exist, it falls back to index.html so that React's client-side
 // router can handle the path.
+//
+// The resolved path is verified to remain within staticDir to prevent
+// directory traversal attacks (e.g. GET /../../etc/passwd).
 func SPAHandler(staticDir string) http.Handler {
-	fs := http.FileServer(http.Dir(staticDir))
+	// Resolve once at startup so every request compares against the same root
+	absStaticDir, err := filepath.Abs(staticDir)
+	if err != nil {
+		panic("SPAHandler: unable to resolve static directory: " + err.Error())
+	}
+
+	fs := http.FileServer(http.Dir(absStaticDir))
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Check if the requested file exists on disk
-		path := filepath.Join(staticDir, filepath.Clean(r.URL.Path))
-		if _, err := os.Stat(path); os.IsNotExist(err) {
-			// File doesn't exist — serve index.html for SPA routing
-			http.ServeFile(w, r, filepath.Join(staticDir, "index.html"))
+		// Resolve the requested path and ensure it stays within the static root
+		requested := filepath.Join(absStaticDir, filepath.Clean(r.URL.Path))
+		if !strings.HasPrefix(requested, absStaticDir+string(filepath.Separator)) && requested != absStaticDir {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+
+		// If the file doesn't exist on disk, fall back to index.html for SPA routing
+		if _, err := os.Stat(requested); os.IsNotExist(err) {
+			http.ServeFile(w, r, filepath.Join(absStaticDir, "index.html"))
 			return
 		}
 

--- a/server/internal/middleware/cors.go
+++ b/server/internal/middleware/cors.go
@@ -1,0 +1,49 @@
+package middleware
+
+import "net/http"
+
+// CORS returns middleware that sets Cross-Origin Resource Sharing headers
+// for requests whose Origin matches the provided allowlist.
+//
+// If allowedOrigins contains "*", every origin is permitted (development only).
+// Preflight OPTIONS requests are handled and short-circuited.
+func CORS(allowedOrigins []string) func(http.Handler) http.Handler {
+	// Build a set for O(1) lookups; also detect the wildcard case
+	allowAll := false
+	originSet := make(map[string]struct{}, len(allowedOrigins))
+	for _, o := range allowedOrigins {
+		if o == "*" {
+			allowAll = true
+		}
+		originSet[o] = struct{}{}
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+
+			// Only set CORS headers when an Origin header is present
+			if origin != "" {
+				if allowAll {
+					w.Header().Set("Access-Control-Allow-Origin", "*")
+				} else if _, ok := originSet[origin]; ok {
+					w.Header().Set("Access-Control-Allow-Origin", origin)
+					// Vary tells caches the response depends on the request origin
+					w.Header().Add("Vary", "Origin")
+				}
+
+				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+				w.Header().Set("Access-Control-Max-Age", "86400")
+			}
+
+			// Short-circuit preflight requests
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}


### PR DESCRIPTION
Fix 1 — Path traversal: server/internal/handlers/handlers.go
Fix 2 — CORS middleware: server/internal/config/config.go, server/internal/middleware/cors.go (new), server/cmd/api/main.go
Fix 3 — Graceful shutdown: server/cmd/api/main.go
Fix 4 — Go version: server/go.mod, docker/server.Dockerfile
Fix 5 — Multi-stage Dockerfile: docker/server.Dockerfile, docker-compose.yml, server/cmd/healthcheck/main.go (new)